### PR TITLE
Fix connection issues

### DIFF
--- a/api/easyrtc.js
+++ b/api/easyrtc.js
@@ -8537,12 +8537,12 @@ var Easyrtc = function() {
            stillAliveTimer = null;
         }
 
-        if (self.webSocketConnected) {
+        if (self.webSocket) {
             if (!preallocatedSocketIo) {
                 self.webSocket.close();
             }
-            self.webSocketConnected = false;
         }
+        self.webSocketConnected = false;
         self.webSocket = 0;
         self.hangupAll();
         if (roomOccupantListener) {

--- a/api/easyrtc.js
+++ b/api/easyrtc.js
@@ -8543,6 +8543,7 @@ var Easyrtc = function() {
             }
             self.webSocketConnected = false;
         }
+        self.webSocket = 0;
         self.hangupAll();
         if (roomOccupantListener) {
             for (key in lastLoggedInList) {
@@ -8559,6 +8560,10 @@ var Easyrtc = function() {
         self.myEasyrtcid = null;
         self.disconnecting = false;
         oldConfig = {};
+
+        if (self.disconnectListener) {
+            self.disconnectListener();
+        }
     }
 
     /**
@@ -8579,25 +8584,7 @@ var Easyrtc = function() {
         // connection until it's had a chance to be sent. We allocate 100ms for collecting
         // the info, so 250ms should be sufficient for the disconnecting.
         //
-        setTimeout(function() {
-            if (self.webSocket) {
-                try {
-                    self.webSocket.disconnect();
-                } catch (e) {
-                    // we don't really care if this fails.
-                }
-
-                closedChannel = self.webSocket;
-                self.webSocket = 0;
-            }
-            self.loggingOut = false;
-            self.disconnecting = false;
-            if (roomOccupantListener) {
-                roomOccupantListener(null, {}, false);
-            }
-            self.emitEvent("roomOccupant", {});
-            oldConfig = {};
-        }, 250);
+        setTimeout(disconnectBody, 250);
     };
 
     /** @private */
@@ -11346,10 +11333,6 @@ var Easyrtc = function() {
             updateConfigurationInfo = function() {}; // dummy update function
             oldConfig = {};
             disconnectBody();
-
-            if (self.disconnectListener) {
-                self.disconnectListener();
-            }
         });
     }
 

--- a/api/easyrtc.js
+++ b/api/easyrtc.js
@@ -11246,6 +11246,7 @@ var Easyrtc = function() {
         }
         else if (!self.webSocket) {
             try {
+               connectionOptions['force new connection'] = true;
                self.webSocket = io.connect(serverPath, connectionOptions);
 
                 if (!self.webSocket) {
@@ -11280,26 +11281,28 @@ var Easyrtc = function() {
             logDebug("the web socket closed");
         });
 
-        addSocketListener('error', function(event) {
-            function handleErrorEvent() {
-                if (self.myEasyrtcid) {
-                    //
-                    // socket.io version 1 got rid of the socket member, moving everything up one level.
-                    //
-                    if (isSocketConnected(self.webSocket)) {
-                        self.showError(self.errCodes.SIGNAL_ERR, self.getConstantString("miscSignalError"));
-                    }
-                    else {
-                        /* socket server went down. this will generate a 'disconnect' event as well, so skip this event */
-                        errorCallback(self.errCodes.CONNECT_ERR, self.getConstantString("noServer"));
-                    }
+        function handleErrorEvent() {
+            if (self.myEasyrtcid) {
+                //
+                // socket.io version 1 got rid of the socket member, moving everything up one level.
+                //
+                if (isSocketConnected(self.webSocket)) {
+                    self.showError(self.errCodes.SIGNAL_ERR, self.getConstantString("miscSignalError"));
                 }
                 else {
+                    /* socket server went down. this will generate a 'disconnect' event as well, so skip this event */
                     errorCallback(self.errCodes.CONNECT_ERR, self.getConstantString("noServer"));
                 }
             }
-            handleErrorEvent();
-        });
+            else {
+                errorCallback(self.errCodes.CONNECT_ERR, self.getConstantString("noServer"));
+            }
+        }
+        addSocketListener('error', handleErrorEvent);
+        if (connectionOptions.reconnection !== false)
+          addSocketListener('reconnect_failed', handleErrorEvent);
+        else
+          addSocketListener('connect_error', handleErrorEvent);
 
         function connectHandler(event) {
             if (!self.webSocket) {

--- a/api/easyrtc_int.js
+++ b/api/easyrtc_int.js
@@ -2983,6 +2983,7 @@ var Easyrtc = function() {
             }
             self.webSocketConnected = false;
         }
+        self.webSocket = 0;
         self.hangupAll();
         if (roomOccupantListener) {
             for (key in lastLoggedInList) {
@@ -2999,6 +3000,10 @@ var Easyrtc = function() {
         self.myEasyrtcid = null;
         self.disconnecting = false;
         oldConfig = {};
+
+        if (self.disconnectListener) {
+            self.disconnectListener();
+        }
     }
 
     /**
@@ -3019,25 +3024,7 @@ var Easyrtc = function() {
         // connection until it's had a chance to be sent. We allocate 100ms for collecting
         // the info, so 250ms should be sufficient for the disconnecting.
         //
-        setTimeout(function() {
-            if (self.webSocket) {
-                try {
-                    self.webSocket.disconnect();
-                } catch (e) {
-                    // we don't really care if this fails.
-                }
-
-                closedChannel = self.webSocket;
-                self.webSocket = 0;
-            }
-            self.loggingOut = false;
-            self.disconnecting = false;
-            if (roomOccupantListener) {
-                roomOccupantListener(null, {}, false);
-            }
-            self.emitEvent("roomOccupant", {});
-            oldConfig = {};
-        }, 250);
+        setTimeout(disconnectBody, 250);
     };
 
     /** @private */
@@ -5786,10 +5773,6 @@ var Easyrtc = function() {
             updateConfigurationInfo = function() {}; // dummy update function
             oldConfig = {};
             disconnectBody();
-
-            if (self.disconnectListener) {
-                self.disconnectListener();
-            }
         });
     }
 

--- a/api/easyrtc_int.js
+++ b/api/easyrtc_int.js
@@ -2977,12 +2977,12 @@ var Easyrtc = function() {
            stillAliveTimer = null;
         }
 
-        if (self.webSocketConnected) {
+        if (self.webSocket) {
             if (!preallocatedSocketIo) {
                 self.webSocket.close();
             }
-            self.webSocketConnected = false;
         }
+        self.webSocketConnected = false;
         self.webSocket = 0;
         self.hangupAll();
         if (roomOccupantListener) {


### PR DESCRIPTION
This fixes #25 by applying the changes I suggested. I also added a 'force new connection' to the connectionOptions.
I've also fixed an issue with `disconnect` closing a pre allocated socket when it shouldn't. See full commit messages for details.

Note: If someone was depending on the roomOccupantListener getting called with `roomName==null` as a way to check if the disconnect is done, then that will break it for them and they'd need to set a `disconnectListener` instead.