### PR TITLE
Fix possible infinite loop with peerClosed

### DIFF
--- a/api/easyrtc.js
+++ b/api/easyrtc.js
@@ -10004,6 +10004,7 @@ var Easyrtc = function() {
               peerConns[otherUser].pc
         ) {
             try {
+                peerConns[otherUser].cancelled = true;
                 var remoteStreams = peerConns[otherUser].pc.getRemoteStreams();
                 for (var i = 0; i < remoteStreams.length; i++) {
                     if (isStreamActive(remoteStreams[i])) {
@@ -10013,7 +10014,6 @@ var Easyrtc = function() {
                 }
 
                 peerConns[otherUser].pc.close();
-                peerConns[otherUser].cancelled = true;
                 logDebug("peer closed");
             } catch (err) {
                 logDebug("peer " + otherUser + " close failed:" + err);

--- a/api/easyrtc_int.js
+++ b/api/easyrtc_int.js
@@ -4444,6 +4444,7 @@ var Easyrtc = function() {
               peerConns[otherUser].pc
         ) {
             try {
+                peerConns[otherUser].cancelled = true;
                 var remoteStreams = peerConns[otherUser].pc.getRemoteStreams();
                 for (var i = 0; i < remoteStreams.length; i++) {
                     if (isStreamActive(remoteStreams[i])) {
@@ -4453,7 +4454,6 @@ var Easyrtc = function() {
                 }
 
                 peerConns[otherUser].pc.close();
-                peerConns[otherUser].cancelled = true;
                 logDebug("peer closed");
             } catch (err) {
                 logDebug("peer " + otherUser + " close failed:" + err);


### PR DESCRIPTION
If hangup is called on the peerClosed handler, then we can have an
infinite loop because the pc.close() will fail with an error saying
the connection is already closed, and cancelled is never set, then
peerClosed gets called again, resulting in another hangup, etc...

Note: I'm still a bit unsure on the proper procedure to recover from a connection error. At the moment, I call hangup, which causes a roomOccupancy handler to be called, which causes me to make a new call. 

Note that the infinite loop happens only on Firefox and seems to freeze up FF until we get a "InternalError: too much recursion" and FF becomes really slow after that  :
![image](https://user-images.githubusercontent.com/27990/78517137-28af7100-778a-11ea-9991-95729e377293.png)

On Chrome, the result is different, it seems the pc gets destroyed before the end of the second call, resulting in another/different crash but less consequential : 
![image](https://user-images.githubusercontent.com/27990/78517336-d3c02a80-778a-11ea-9be3-1e83e62c472e.png)
