### PR TITLE
Add Open-EasyRTC logo assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="./docs/images/open-easyrtc_logo.svg" alt="Open-EasyRTC" width="200" height="60">
+</p>
+
 Open-EasyRTC
 =======
 
@@ -65,6 +69,8 @@ All documentation can be found within [the docs folder](./docs/).
      * `https://open-easyrtc.github.io/open-easyrtc/client/Easyrtc_App.html`
 
 **General Development**
+ * [Brand assets](./docs/brand.md)
+     * `/docs/brand.md`
  * [Frequently asked questions](./docs/easyrtc_faq.md)
      * `/docs/easyrtc_faq.md`
  * [Authentication](./docs/easyrtc_authentication.md/)

--- a/demos/images/LICENSE
+++ b/demos/images/LICENSE
@@ -6,3 +6,5 @@ Browser logos are copyright by their respective owner.
 Logos for Skedans Systems, Inc and EasyRTC are owned by Skedans Systems, Inc.
 
 Permission is granted to use powered_by_easyrtc.png within your own application as long as it is not altered in any way.
+
+The Open-EasyRTC logo SVG is project-owned and distributed under the repository license.

--- a/demos/images/open-easyrtc_logo.svg
+++ b/demos/images/open-easyrtc_logo.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="60" viewBox="0 0 200 60" role="img" aria-labelledby="open-easyrtc-title open-easyrtc-desc">
+  <title id="open-easyrtc-title">Open-EasyRTC logo</title>
+  <desc id="open-easyrtc-desc">A rounded orange Open-EasyRTC wordmark with a white open communication ring and connected WebRTC nodes.</desc>
+  <defs>
+    <linearGradient id="open-easyrtc-bg" x1="0" y1="0" x2="200" y2="60" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#ff7a1a"/>
+      <stop offset="1" stop-color="#f04f23"/>
+    </linearGradient>
+    <filter id="open-easyrtc-shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="2" stdDeviation="2" flood-color="#612000" flood-opacity=".22"/>
+    </filter>
+  </defs>
+  <rect width="200" height="60" rx="10" fill="url(#open-easyrtc-bg)"/>
+  <g filter="url(#open-easyrtc-shadow)">
+    <circle cx="31" cy="30" r="17" fill="none" stroke="#ffffff" stroke-width="5" stroke-linecap="round" stroke-dasharray="75 18"/>
+    <path d="M42.5 20.5h12a6 6 0 0 1 6 6v7a6 6 0 0 1-6 6h-5.8l-7 6.2v-6.2h-2.5" fill="none" stroke="#ffffff" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+    <circle cx="23" cy="30" r="3.4" fill="#ffffff"/>
+    <circle cx="31" cy="30" r="3.4" fill="#ffffff"/>
+    <circle cx="39" cy="30" r="3.4" fill="#ffffff"/>
+  </g>
+  <g font-family="Arial, Helvetica, sans-serif" letter-spacing="0">
+    <text x="73" y="27" fill="#ffffff" font-size="19" font-weight="700">Open</text>
+    <text x="73" y="46" fill="#241008" font-size="21" font-weight="700">EasyRTC</text>
+  </g>
+</svg>

--- a/demos/index.html
+++ b/demos/index.html
@@ -8,7 +8,7 @@
 <body>
 <div id="container">
     <div id="header">
-        <a href="index.html"><img id="logo_easyrtc" src="images/easyrtc_logo.png" alt="EasyRTC" style="" /></a>
+        <a href="index.html"><img id="logo_easyrtc" src="images/open-easyrtc_logo.svg" alt="Open-EasyRTC" width="200" height="60" /></a>
     </div>
     <div id="menu">
         <a class="menu_link" href="index.html"><span class="menu_item">Local Demos</span></a>

--- a/docs/brand.md
+++ b/docs/brand.md
@@ -1,0 +1,16 @@
+# Open-EasyRTC brand assets
+
+The project logo is available as a scalable SVG for documentation, demos, and package pages:
+
+<img src="images/open-easyrtc_logo.svg" alt="Open-EasyRTC logo" width="200" height="60">
+
+## Palette
+
+| Use | Color |
+| --- | --- |
+| Primary orange | `#ff7a1a` |
+| Deep orange | `#f04f23` |
+| Text dark | `#241008` |
+| Mark white | `#ffffff` |
+
+Use the SVG source rather than rasterizing it when possible, so the mark stays sharp in generated docs and high-DPI screens.

--- a/docs/images/open-easyrtc_logo.svg
+++ b/docs/images/open-easyrtc_logo.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="60" viewBox="0 0 200 60" role="img" aria-labelledby="open-easyrtc-title open-easyrtc-desc">
+  <title id="open-easyrtc-title">Open-EasyRTC logo</title>
+  <desc id="open-easyrtc-desc">A rounded orange Open-EasyRTC wordmark with a white open communication ring and connected WebRTC nodes.</desc>
+  <defs>
+    <linearGradient id="open-easyrtc-bg" x1="0" y1="0" x2="200" y2="60" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#ff7a1a"/>
+      <stop offset="1" stop-color="#f04f23"/>
+    </linearGradient>
+    <filter id="open-easyrtc-shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="2" stdDeviation="2" flood-color="#612000" flood-opacity=".22"/>
+    </filter>
+  </defs>
+  <rect width="200" height="60" rx="10" fill="url(#open-easyrtc-bg)"/>
+  <g filter="url(#open-easyrtc-shadow)">
+    <circle cx="31" cy="30" r="17" fill="none" stroke="#ffffff" stroke-width="5" stroke-linecap="round" stroke-dasharray="75 18"/>
+    <path d="M42.5 20.5h12a6 6 0 0 1 6 6v7a6 6 0 0 1-6 6h-5.8l-7 6.2v-6.2h-2.5" fill="none" stroke="#ffffff" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+    <circle cx="23" cy="30" r="3.4" fill="#ffffff"/>
+    <circle cx="31" cy="30" r="3.4" fill="#ffffff"/>
+    <circle cx="39" cy="30" r="3.4" fill="#ffffff"/>
+  </g>
+  <g font-family="Arial, Helvetica, sans-serif" letter-spacing="0">
+    <text x="73" y="27" fill="#ffffff" font-size="19" font-weight="700">Open</text>
+    <text x="73" y="46" fill="#241008" font-size="21" font-weight="700">EasyRTC</text>
+  </g>
+</svg>


### PR DESCRIPTION
Closes #34.

## Summary
- Add a reusable SVG Open-EasyRTC logo for documentation and demo use.
- Add a short brand-assets page with the palette used by the logo.
- Show the new mark at the top of the README and on the local demo landing page.
- Note the project-owned SVG in the demo images license file.

## Validation
- `npm run lint`
- Parsed both SVG copies as XML.
- Checked the README and demo landing-page logo links.
- Rendered the SVG preview locally with ImageMagick to verify sizing and legibility.